### PR TITLE
Make Vue Formly compatible with SSR & Nuxt

### DIFF
--- a/src/components/FormlyField.js
+++ b/src/components/FormlyField.js
@@ -1,0 +1,131 @@
+import Util, {getTypes, setError, parseValidationString } from '../util';
+export default {
+  render(h){
+    if ( !this.display ) return;
+    return h(this.type, {
+      props: {
+	form: this.form,
+	field: this.field,
+	model: this.model,
+	to: this.field.templateOptions
+      }
+    });
+  },
+  props: ['form', 'model', 'field', 'to'],
+  computed: {
+    type:function(){
+      return 'formly_'+this.field.type;
+    },
+    display: function(){
+      // always show if there is no conditional display
+      let displayType = typeof this.field.display;
+      if ( displayType !== 'function' && displayType !== 'string' ) return true;
+
+      if ( displayType === 'function' ){
+	return this.field.display( this.field, this.model );       
+      } else {
+	let result = new Function('field', 'model',  'return '+this.field.display+';' );
+	return result.call({}, this.field, this.model);
+      }
+    }
+  },
+  methods: {
+    validate:function(){
+      return new Promise((resolve, reject)=>{
+	//first check if we need to create a field
+	if ( !this.form.$errors[this.field.key] ) this.$set(this.form.$errors, this.field.key, {});
+	if ( !this.field.templateOptions ) this.$set(this.field, 'templateOptions', {});
+
+	let label = ( 'templateOptions' in this.field ) && ( 'label' in this.field.templateOptions ) ? this.field.templateOptions.label : '';
+	
+	//check for required fields. This whole setting,unsetting thing seems kind of wrong though..
+	//there might be a more 'vue-ey' way to do this...
+	if ( this.field.required ){
+          if ( !this.form.$errors[this.field.key].required ) this.$set(this.form.$errors[ this.field.key ], 'required', true);
+	  let requiredError = parseValidationString( 'required', false, label, this.model[ this.field.key ] );
+	  let requiredType = typeof this.model[ this.field.key ] === 'string' ? !this.model[ this.field.key ] : this.model[ this.field.key ].length === 0;
+	  let required = this.display ? requiredType : false;
+          setError(this.form, this.field.key, 'required', required, requiredError) ;
+	}
+	
+	//if we've got nothing left then return
+	if ( !this.field.validators ) return resolve();
+
+	//set these for the validators so we don't have to use 'this' in them
+	let model = this.model;
+	let field = this.field;
+	
+	Object.keys(this.field.validators).forEach((validKey) => {
+          if ( !this.form.$errors[this.field.key][validKey] ) this.$set(this.form.$errors[ this.field.key ], validKey, false);
+          if ( !this.field.required && !this.model[ this.field.key ] ) {
+	    setError(this.form, this.field.key, validKey, false );
+	    return resolve();
+	  }
+
+          let validator = this.field.validators[validKey];
+          let validatorMessage = false;
+
+          if ( typeof validator === 'object' ){
+            if ( !( 'message' in validator ) ){
+              console.error( "Looks like you've set a validator object without setting a message. If you don't need to explicity set the message just define the validator as either an expression or a function. Refer to the docs for more info");
+            } else {
+              validatorMessage = validator.message;
+              validator = validator.expression;
+            }
+          }
+          
+          validatorMessage = parseValidationString( validKey, validatorMessage, label, model[ this.field.key ] );
+
+          let valid = false;
+          if ( typeof validator === 'function' ){
+	    //set the asynchronous flag so that we know it's going
+	    let asyncKey = '$async_'+validKey;
+	    this.$set(this.form.$errors[ this.field.key ], asyncKey, true);
+	    
+            // setup for async validation
+            validator(field, model, (asyncValid = false, asyncValidatorMessage = validatorMessage) => {
+              // whenever validation is done via a function we will assume it's asynchronous and will require next() to be called
+              // this way it doesn't matter if it's async or not, next() should always be called
+              setError(this.form, this.field.key, validKey, !asyncValid, asyncValidatorMessage);
+	      this.$set(this.form.$errors[ this.field.key ], asyncKey, false);
+	      resolve();
+            });
+          } else {
+            let res = new Function('model', 'field', 'return '+validator+';' );
+            valid = !res.call({}, model, field);
+            setError(this.form, this.field.key, validKey, valid, validatorMessage);
+	    resolve();
+          }
+          
+	});
+      });
+    }
+  },
+  components: getTypes(),
+  created(){
+    this.validate();
+    this.$watch(function(){
+      return this.model[ this.field.key ];
+    }, (val) =>{
+      let valid = this.validate();
+    });
+  },
+  mounted(){
+    if ( !this.field.wrapper ) return;
+    
+    //create a temporary element
+    let wrapper = document.createElement('DIV');
+    //populate it with the wrapper string
+    wrapper.innerHTML = this.field.wrapper;
+    //get the parent
+    let parent = this.$el.parentNode;
+    //insert the wrapper before this element
+    parent.insertBefore(wrapper, this.$el);
+    //append the element to the new wrapper
+    wrapper.firstChild.appendChild( this.$el );
+    //move the new wrapper back to where it should be
+    parent.insertBefore(wrapper.firstChild, wrapper);
+    //remove the temporary element
+    parent.removeChild(wrapper);
+  }
+}

--- a/src/components/FormlyField.vue
+++ b/src/components/FormlyField.vue
@@ -1,5 +1,5 @@
 <template>
-  <component v-show="display" :is="type" :form.sync="form" :field="field" :model="model" :to="field.templateOptions"></component>
+  <component v-if="display" :is="type" :form.sync="form" :field="field" :model="model" :to="field.templateOptions"></component>
 </template>
 
 <script>

--- a/src/components/FormlyForm.js
+++ b/src/components/FormlyForm.js
@@ -1,0 +1,98 @@
+export default {
+  render(h){
+    let children = [];
+    if ( !this.customLayout ){
+      const self = this;
+      children = this.fields.map( function(field){
+	return h('formly-field', {
+	  domProps: {
+	    ref: field.key,
+	    model: self.model,
+	    form: self.form,
+	    field: field,
+	    key: `formly_{field.key}`
+	  }
+	});
+      });
+    }
+    if ( 'default' in this.$scopedSlots ) children.push( this.$scopedSlots.default({ keys: this.keys }) );
+    return h('fieldset', children);
+  },
+  methods: {
+    validate(){
+      return new Promise((resolve, reject) => {
+	let target = this.fields.length;
+	let count = 0;
+	this.fields.forEach( field => {
+	  if ( !(field.key in this.form) ) {
+	    count++;
+	    if( target == count ) resolve();
+	    return;
+	  }
+	  this.$set( this.form[ field.key ], '$dirty', true );
+	  let validate;
+	  if ( field.key in this.$refs ){
+	    validate = this.$refs[ field.key ][0].validate;
+	  } else {
+	    this.$children.some( child => {
+	      if ( ! ( 'field' in child ) ) return false;
+	      if ( child.field.key === field.key ){
+		validate = child.validate;
+		return true;
+	      }
+	    });
+	  }
+	  if ( typeof validate !== 'function' ){
+	    count++;
+	    if( target == count ) resolve();
+	    return;
+	  }
+	  validate()
+	    .then(()=>{
+	      count++;
+	      if( target == count ) resolve();
+	    })
+	    .catch((e)=>{
+	      reject(e);
+	    });
+	});
+      });
+    }
+  },
+  props: ['form', 'model', 'fields', 'customLayout'],
+  computed:{
+    keys(){
+      let keys = {};
+      this.fields.forEach( field => {
+	keys[field.key] = field;
+      });
+      return keys;
+    }
+  },
+  created(){
+
+    //make sure that the 'value' is always set
+    this.fields.forEach( field => {
+      if ( typeof this.model[ field.key ] == 'undefined' ) this.$set(this.model, field.key, '');
+    });
+
+    
+    //set our validation options
+    this.$set(this.form, '$errors', {});
+    this.$set(this.form, '$valid', true);
+
+    this.$watch('form.$errors', function(val){
+      let valid = true;
+      Object.keys(this.form.$errors).forEach((key)=>{
+        let errField = this.form.$errors[key];
+        Object.keys(errField).forEach((errKey) => {
+          if ( errField[errKey] ) valid = false;
+        })
+      });
+      this.form.$valid = valid;
+    }, {
+      deep: true
+    });
+    
+  }
+}

--- a/src/components/FormlyForm.js
+++ b/src/components/FormlyForm.js
@@ -32,7 +32,7 @@ export default {
 	  this.$set( this.form[ field.key ], '$dirty', true );
 	  let validate;
 	  if ( field.key in this.$refs ){
-	    validate = this.$refs[ field.key ][0].validate;
+	    validate = this.$refs[ field.key ].validate;
 	  } else {
 	    this.$children.some( child => {
 	      if ( ! ( 'field' in child ) ) return false;
@@ -42,11 +42,13 @@ export default {
 	      }
 	    });
 	  }
+
 	  if ( typeof validate !== 'function' ){
 	    count++;
 	    if( target == count ) resolve();
 	    return;
 	  }
+
 	  validate()
 	    .then(()=>{
 	      count++;

--- a/src/components/FormlyForm.js
+++ b/src/components/FormlyForm.js
@@ -5,12 +5,12 @@ export default {
       const self = this;
       children = this.fields.map( function(field){
 	return h('formly-field', {
-	  domProps: {
-	    ref: field.key,
+	  key: `formly_{field.key}`,
+	  ref: field.key,
+	  props: {
 	    model: self.model,
 	    form: self.form,
-	    field: field,
-	    key: `formly_{field.key}`
+	    field: field
 	  }
 	});
       });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
-import FormlyForm from './FormlyForm.vue';
+import FormlyForm from './FormlyForm';
 import FormlyField from './FormlyField.vue';
 
 export default function(Vue){

--- a/test/unit/specs/FormlyField.spec.js
+++ b/test/unit/specs/FormlyField.spec.js
@@ -27,6 +27,8 @@ function createForm(template, data){
 
 describe('FormlyField', () => {
 
+  return;
+
   it('should take on the type of another component', () => {
 
     Vue.component('formly_test', {

--- a/test/unit/specs/FormlyField.spec.js
+++ b/test/unit/specs/FormlyField.spec.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 const expect = chai.expect;
 import Vue from 'vue';
-import FormlyField from 'src/components/FormlyField.vue';
+import FormlyField from 'src/components/FormlyField';
 import Utils from 'src/util';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -26,8 +26,6 @@ function createForm(template, data){
 
 
 describe('FormlyField', () => {
-
-  return;
 
   it('should take on the type of another component', () => {
 
@@ -185,7 +183,7 @@ describe('FormlyField', () => {
     };
 
     createForm('<formly-field :form.sync="form" :field="fields[0]" :model="model"></formly-field>', data);
-    expect(vm.$el.style.display).to.equal('none');
+    expect(vm.$el.nodeName).to.equal('#comment');
     data.model.hiddenVal = 'hello';
     setTimeout(()=>{
       expect(vm.$el.style.display).to.equal('');
@@ -218,7 +216,7 @@ describe('FormlyField', () => {
     };
 
     createForm('<formly-field :form.sync="form" :field="fields[0]" :model="model"></formly-field>', data);
-    expect(vm.$el.style.display).to.equal('none');
+    expect(vm.$el.nodeName).to.equal('#comment');
     data.model.hiddenStringVal = 'hello';
     setTimeout(()=>{
       expect(vm.$el.style.display).to.equal('');

--- a/test/unit/specs/FormlyForm.spec.js
+++ b/test/unit/specs/FormlyForm.spec.js
@@ -222,11 +222,10 @@ describe('FormlyForm', () => {
       template: '<formly-form :form="form" :model="model" :fields="fields"></formly-form>'
     }).$mount(el);
     
-    
     let spy = sinon.spy();
 
     let prom = vm.$children[0].validate();
-    prom.then(()=>spy()).catch((e)=>console.log(e));
+    prom.then(()=>spy());
     setTimeout(()=>{
       spy.should.be.calledOnce;
       formlyFieldSpy.should.be.calledTwice;

--- a/test/unit/specs/FormlyForm.spec.js
+++ b/test/unit/specs/FormlyForm.spec.js
@@ -226,7 +226,7 @@ describe('FormlyForm', () => {
     let spy = sinon.spy();
 
     let prom = vm.$children[0].validate();
-    prom.then(()=>spy());
+    prom.then(()=>spy()).catch((e)=>console.log(e));
     setTimeout(()=>{
       spy.should.be.calledOnce;
       formlyFieldSpy.should.be.calledTwice;

--- a/test/unit/specs/FormlyForm.spec.js
+++ b/test/unit/specs/FormlyForm.spec.js
@@ -3,7 +3,7 @@ const expect = chai.expect;
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import Vue from 'vue';
-import FormlyForm from 'src/components/FormlyForm.vue';
+import FormlyForm from 'src/components/FormlyForm';
 import Filters from 'src/filters/index';
 Vue.component('formly-form', FormlyForm);
 chai.use(sinonChai);


### PR DESCRIPTION
Nuxt is throwing errors about using the runtime only build of Vue so we need to move all our templates over to render functions.