### PR TITLE
Change required check to exactly equal false

### DIFF
--- a/src/components/FormlyField.js
+++ b/src/components/FormlyField.js
@@ -60,7 +60,7 @@ export default {
 	
 	Object.keys(this.field.validators).forEach((validKey) => {
           if ( !this.form.$errors[this.field.key][validKey] ) this.$set(this.form.$errors[ this.field.key ], validKey, false);
-          if ( !this.field.required && !this.model[ this.field.key ] ) {
+          if ( this.field.required === false && !this.model[ this.field.key ] ) {
 	    setError(this.form, this.field.key, validKey, false );
 	    return resolve();
 	  }

--- a/test/unit/specs/FormlyField.spec.js
+++ b/test/unit/specs/FormlyField.spec.js
@@ -396,6 +396,7 @@ describe('FormlyField', () => {
           {
             key: 'search',
             type: 'test',
+            required: false,
             validators: {
               expression: 'field.value == "test"'
             }
@@ -445,6 +446,29 @@ describe('FormlyField', () => {
         done();
       },0);
     });
+
+    it('should run validators even if require does not exists and model is empty', done => {
+      let data = {
+        form: {
+          $valid: true,
+          $errors: {}
+        },
+        model: {
+          search: null
+        },
+        fields: [
+          {
+            key: 'search',
+            type: 'test',
+            validators: {
+              aValidator: () => done()
+            }
+          }
+        ]
+      };
+
+      createValidField(data);
+    })
 
     it('Async Validation', (done) => {
       let data = {


### PR DESCRIPTION
If omitted, the required field check should not skip the manual validations (when the model value is empty). This way the user can know that the field is empty, and handle this emptiness as needed.